### PR TITLE
Updated webkit detection

### DIFF
--- a/lib/jquery.simplr.smoothscroll.js
+++ b/lib/jquery.simplr.smoothscroll.js
@@ -23,7 +23,7 @@
         step = self.step,
         speed = self.speed,
         viewport = win.height(),
-        body = $.browser.webkit ? $('body') : $('html'),
+        body = (navigator.userAgent.indexOf('AppleWebKit') !== -1) ? $('body') : $('html'),
         wheel = false;
 
     // events


### PR DESCRIPTION
$.browser was removed in jQuery 1.9. A better option may be to use $.support, but this does the trick for now.
